### PR TITLE
Fixes startup problems with SonarQube 7.8+

### DIFF
--- a/templates/sonar.properties.j2
+++ b/templates/sonar.properties.j2
@@ -85,7 +85,7 @@ sonar.ce.workerCount={{ sonar_ce_worker_count | default('1') }}
 #--------------------------------------------------------------------------------------------------
 # ELASTICSEARCH
 
-sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms1G -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError') }}
+sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms1G -Xss256k -Djava.net.preferIPv4Stack=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError') }}
 sonar.search.javaAdditionalOpts={{ sonar_search_java_additional_opts | default('') }}
 sonar.search.port={{ sonar_search_port | default('9001') }}
 sonar.search.host={{ sonar_search_host | default('127.0.0.1') }}

--- a/templates/sonar.properties.j2
+++ b/templates/sonar.properties.j2
@@ -85,7 +85,7 @@ sonar.ce.workerCount={{ sonar_ce_worker_count | default('1') }}
 #--------------------------------------------------------------------------------------------------
 # ELASTICSEARCH
 
-sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms256m -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError') }}
+sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms1G -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError') }}
 sonar.search.javaAdditionalOpts={{ sonar_search_java_additional_opts | default('') }}
 sonar.search.port={{ sonar_search_port | default('9001') }}
 sonar.search.host={{ sonar_search_host | default('127.0.0.1') }}


### PR DESCRIPTION
This fixes ES startup problems that come from
* too small inital heap (see below)
* obsolete JDK Garbage Collection tuning options that make the JVM exit at startup

With this PR the default options permit to install a standard sonarqube-8.1.0.31237

[1]: initial heap size [268435456] not equal to maximum heap size [1073741824]; this can cause resize pauses and prevents mlockall from locking the entire heap
2020.01.10 11:00:38 WARN app[][o.s.a.p.AbstractManagedProcess] Process exited with exit value [es]: 78