### PR TITLE
Do not overwrite sonar_search_java_opts (fixes #26)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -172,7 +172,8 @@ sonar_ce_worker_count: 1
 #    is not enabled by default on your environment:
 #    http://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html
 #
-sonar_search_java_opts: "-Xmx1G -Xms256m -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError"
+# sonar_search_java_opts: "-Xmx1G -Xms1G -Xss256k -Djava.net.preferIPv4Stack=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError"
+sonar_search_java_opts: ""
 
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 sonar_search_java_additional_opts: ""

--- a/templates/sonar.properties.j2
+++ b/templates/sonar.properties.j2
@@ -85,7 +85,7 @@ sonar.ce.workerCount={{ sonar_ce_worker_count | default('1') }}
 #--------------------------------------------------------------------------------------------------
 # ELASTICSEARCH
 
-sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms1G -Xss256k -Djava.net.preferIPv4Stack=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError') }}
+sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms1G -Xss256k -Djava.net.preferIPv4Stack=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError', true) }}
 sonar.search.javaAdditionalOpts={{ sonar_search_java_additional_opts | default('') }}
 sonar.search.port={{ sonar_search_port | default('9001') }}
 sonar.search.host={{ sonar_search_host | default('127.0.0.1') }}


### PR DESCRIPTION
Update defaults/main.yml to not overwrite defaults for sonar_search_java_opts set in templates/sonar.properties.j2