### PR TITLE
List additional Molecule dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
 install:
   - pip install --quiet molecule
   - pip install --quiet 'molecule[docker]'
+  - pip install --quiet ansible-lint
+  - pip install --quiet flake8
+  - pip install --quiet pytest-testinfra
 
 before_script:
   - molecule --version


### PR DESCRIPTION
Hi. The [latest build](https://travis-ci.org/github/lrk/ansible-role-sonarqube/builds) in this repository was failed with message `ansible-lint: not found`

When install the ansible-lint with PIP, Molecule fail in attempt to find Flake8. 
When install the Flake8, Molecule complete the `converge` and `idempotence` stages - but finally fails with the message which seems to be related to https://github.com/ansible-community/molecule/issues/2597

I need to fix Molecule tests for https://github.com/lrk/ansible-role-sonarqube/issues/30 - so this PR propose describe missed dependencies in .travis-ci.yml

Let me to pay your attention:
- `pytest-testinfra` package might not be required if you'll decide to remove the folder [molecule/default/tests](molecule/default/tests) which currently contain only default tests
- `molecule test` currently say ` playbook.yml was deprecated, rename it to converge.yml`. After rename it will continue works, but with warnings `Couldn't open molecule/default/playbook.yml - No such file or directory`. Unfortunately I don't fixed this issue, so don't renamed anything.

Looking forward for your feedback.