### PR TITLE
Allow the SonarQube upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
 install:
   - pip install --quiet molecule
   - pip install --quiet 'molecule[docker]'
+  - pip install --quiet ansible-lint
+  - pip install --quiet flake8
+  - pip install --quiet pytest-testinfra
 
 before_script:
   - molecule --version

--- a/README.md
+++ b/README.md
@@ -392,6 +392,29 @@ Example Playbook
       - lrk.sonarqube
 ```
 
+Upgrade
+------------
+Please test upgrade in staging environment first
+
+Process consist of the next steps:
+
+1. Change the var `sonar_version`
+2. Review the var `sonar_plugins` in accordance with https://docs.sonarqube.org/latest/instance-administration/plugin-version-matrix/
+3. Run the role over existing installation. Ansible will:
+- create the installation folder
+- place here the binaries of new SonarQube with plugins
+- stop the currently running service
+- update configs
+- start service again
+- ensure web-service started and SonarQube version number appear in web.log
+- ensure that running Sonar version correspond to expected
+4. Then you need open http://yourSonarQubeServerURL/setup and follow the setup instructions as described in https://docs.sonarqube.org/latest/setup/upgrading/ (role output leave a reminder for this)
+
+Please pay your attention:
+- role doesn't backup the database
+- role doesn't compare the versions. Please avoid of making downgrade by mistake
+- role doesn't remove the folder with previous installation, so after upgrade the path specified in variable `sonar_install_directory` will contain more than one `sonar_base_dir`
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Available variables along with default values are listed below (see `defaults/ma
   #    is not enabled by default on your environment:
   #    http://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html
   #
-  sonar_search_java_opts: "-Xmx1G -Xms256m -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError"
+  sonar_search_java_opts: "-Xmx1G -Xms256m -Xss1m -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError"
 
   # Same as previous property, but allows to not repeat all other settings like -Xmx
   sonar_search_java_additional_opts: ""

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,10 @@
   service:
     name: sonar
     state: restarted
+
+- name: "fail if expected sonar version not found in log"
+  ansible.builtin.fail:
+    msg:
+      Not found log record about start of web UI for version {{ sonar_version }}.
+      Please verify the 'Version' field of http://{{ inventory_hostname }}{{ sonar_web_context }}.
+      Logs could be found in {{ sonar_logs_dir }} and {{ sonar_base_dir }}/logs

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,8 +6,14 @@
     state: restarted
 
 - name: "fail if expected sonar version not found in log"
-  ansible.builtin.fail:
+  fail:
     msg:
       Not found log record about start of web UI for version {{ sonar_version }}.
       Please verify the 'Version' field of http://{{ inventory_hostname }}{{ sonar_web_context }}.
       Logs could be found in {{ sonar_logs_dir }} and {{ sonar_base_dir }}/logs
+
+- name: "warn about post-upgrade steps"
+  debug:
+    msg:
+      - "SonarQube version changed to {{ sonar_version }} but additional actions required from your side"
+      - "Visit http://{{ inventory_hostname }}{{ sonar_web_context }}/setup to follow the post-upgrade procedure"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -19,12 +19,60 @@
       apt:
         update_cache: yes
       when: ansible_distribution == 'Ubuntu'
+
     - name: "Install package dependencies"
       package:
         name: "{{ item }}"
         state: "present"
       with_items:
         - unzip
+
+    # Block below added because the geerlingguy.java role in Debian 8
+    # install by default the OpenJDK 7 as described in
+    # https://github.com/geerlingguy/ansible-role-java/blob/master/vars/Debian-8.yml
+
+    # The Java 7 is not supported by SonarQube 7.3 as shown in
+    # https://docs.sonarqube.org/7.3/Requirements.html
+
+    # With Java 7 Sonar service attempt to start,
+    # but later fail with error "Unsupported major.minor version 52.0"
+
+    # These steps added only for Molecule and role may have described problem.
+    # Here it needed as workaround to have tests passed for
+    # https://github.com/lrk/ansible-role-sonarqube/issues/30 and do not change role logic.
+
+    # Maybe it's time discontinue support of Debian 8 (EOL was June 30, 2020)
+
+    - name: "Install Java 8 in Debian 8 as it doesn't supported by Geerlingguy role"
+      when: ansible_distribution_release == "jessie"
+      block:
+        - name: "Debian 8 - disable repository valid-until check"
+          lineinfile:
+            path: /etc/apt/apt.conf
+            line: Acquire::Check-Valid-Until "false";
+            create: yes
+            owner: root
+            group: root
+            mode: 0644
+
+        - name: "Debian 8 - add jessie-backports repo"
+          apt_repository:
+            repo: deb http://archive.debian.org/debian jessie-backports main
+            state: present
+
+        - name: "Debian 8 - ensure apt cache is up to date"
+          apt:
+            update_cache: yes
+          changed_when: no
+
+        - name: "Debian 8 - install openjdk-8-jdk"
+          command: apt install -t jessie-backports openjdk-8-jdk -y
+          changed_when: no
+
+        - name: "Debian 8 - set java_packages value to supported by Sonar"
+          set_fact:
+            java_packages:
+              - openjdk-8-jdk
 
   roles:
     - role: geerlingguy.java

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,6 +2,7 @@
 - name: Converge
   hosts: all
   vars:
+    sonar_version: 7.3
     sonar_plugins:
       - name: "sonar-l10n-pt"
         version: "6.4"

--- a/molecule/default/side_effect.yml
+++ b/molecule/default/side_effect.yml
@@ -1,0 +1,13 @@
+---
+# side_effect playbook from https://molecule.readthedocs.io/en/latest/configuration.html
+# We use default test_sequence so Molecule initialize this playbook after the idempotence check
+
+- name: Side Effect
+  hosts: all
+  vars:
+    sonar_version: 7.4
+    sonar_plugins: []
+  tasks:
+    - name: "Start role again and apply upgrade to {{ sonar_version }}"
+      include_role:
+        name: ansible-role-sonarqube

--- a/molecule/default/side_effect.yml
+++ b/molecule/default/side_effect.yml
@@ -8,6 +8,14 @@
     sonar_version: 7.4
     sonar_plugins: []
   tasks:
+
+    # First task is a part of Debian 8 workaround from molecule/default/playbook.yml
+    - name: "Debian 8 - set java_packages value to supported by Sonar"
+      set_fact:
+        java_packages:
+          - openjdk-8-jdk
+      when: ansible_distribution_release == "jessie"
+
     - name: "Start role again and apply upgrade to {{ sonar_version }}"
       include_role:
         name: ansible-role-sonarqube

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,3 +50,25 @@
   with_items: "{{ sonar_plugins }}"
   loop_control:
     loop_var: "sonar_cplugin"
+
+- meta: flush_handlers
+
+- name: "Ensure web-interface is started"
+  uri:
+    url: "http://{{ sonar_web_host }}:{{ sonar_web_port }}/{{ sonar_web_context }}/"
+    method: GET
+  register: _sonar_page
+  until: _sonar_page.status == 200
+  retries: 60
+  delay: 5
+  check_mode: no # because this module does not support check mode
+  ignore_errors: "{{ ansible_check_mode }}"
+
+  # task always run in check mode and have a status 'changed' when row missed
+  # more details in https://stackoverflow.com/a/46454251
+- name: "Verify the Sonar version"
+  lineinfile:
+    dest: "{{ sonar_logs_dir }}/web.log"
+    line: "SonarQube Server / {{ sonar_version }}"
+  check_mode: yes
+  notify: fail if expected sonar version not found in log

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,11 +64,11 @@
   check_mode: no # because this module does not support check mode
   ignore_errors: "{{ ansible_check_mode }}"
 
-  # task always run in check mode and have a status 'changed' when row missed
-  # more details in https://stackoverflow.com/a/46454251
 - name: "Verify the Sonar version"
-  lineinfile:
-    dest: "{{ sonar_logs_dir }}/web.log"
-    line: "SonarQube Server / {{ sonar_version }}"
-  check_mode: yes
-  notify: fail if expected sonar version not found in log
+  command: "grep 'SonarQube Server / {{ sonar_version }}' {{ sonar_logs_dir }}/web.log"
+  register: grep_version
+  check_mode: no
+  failed_when: grep_version.rc >= 2 # for example, if log not found
+  changed_when: grep_version.rc == 1 # if log found, but string not exist
+  notify: fail if expected sonar version not found in log # triggered on change
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/setup_sonarqube.yml
+++ b/tasks/setup_sonarqube.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: "Ensure SonarQube binary exists"
+- name: "Check if SonarQube binary exists"
   stat:
     path: "{{ sonar_daemon_dir }}/sonar.sh"
   register: sonar_binary_stat
@@ -26,6 +26,16 @@
       path: "/tmp/{{ __sonar_archive }}"
       state: absent
 
+  - name: "Collect the list of services to check if sonar.service exists"
+    service_facts:
+
+  - name: "Stop service before upgrade"
+    service:
+      name: sonar
+      state: stopped
+    when: '"sonar.service" in ansible_facts.services'
+    notify: warn about post-upgrade steps
+
   when: not sonar_binary_stat.stat.exists
 
 - name: "Ensure SonarQube as init script for service management"
@@ -42,7 +52,14 @@
     owner: root
     group: root
     mode: 0755
+  register: systemd_service
   when: "ansible_service_mgr == 'systemd'"
+
+- name: Force systemd to reread configs
+  systemd:
+    daemon_reload: yes
+  tags: skip_ansible_lint
+  when: systemd_service is defined and systemd_service.changed
 
 - name: "Ensure SonarQube is running and set to start on boot."
   service:

--- a/templates/sonar.properties.j2
+++ b/templates/sonar.properties.j2
@@ -85,7 +85,7 @@ sonar.ce.workerCount={{ sonar_ce_worker_count | default('1') }}
 #--------------------------------------------------------------------------------------------------
 # ELASTICSEARCH
 
-sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms1G -Xss256k -Djava.net.preferIPv4Stack=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError', true) }}
+sonar.search.javaOpts={{ sonar_search_java_opts | default('-Xmx1G -Xms1G -Xss1m -Djava.net.preferIPv4Stack=true -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError', true) }}
 sonar.search.javaAdditionalOpts={{ sonar_search_java_additional_opts | default('') }}
 sonar.search.port={{ sonar_search_port | default('9001') }}
 sonar.search.host={{ sonar_search_host | default('127.0.0.1') }}


### PR DESCRIPTION
Hi. This PR proposed to resolve https://github.com/lrk/ansible-role-sonarqube/issues/30
Text highlight the part of commits, and I'll be appreciate for review of all changes.

https://github.com/lrk/ansible-role-sonarqube/commit/ed267d15791846cdc48d28a406898aad28dac4b6 update Molecule with additional step for application upgrade

Without additional checks this step may return the false-positive "success" showing the problem described in initial issue.

I was think how to verify what version actually started. SonarQube login page have this info, but I wasn't able fetch the version number with a `curl` or Ansible `uri` module. However when web-UI start, next row appear in web.log:
```
2021.01.11 21:25:08 INFO  web[][o.s.s.p.LogServerVersion] SonarQube Server / 7.3.0.15553 / 7f72262e02808e9431d97735ece621a22a1d8208
```
It seems to be a stable behavior (checked with web.log of Sonar 7.3/7.4/7.9) - so the `tasks/main.yml` was updated with two checks:
1. Ansible waiting for start of the web-interface (timeout 5 minutes) 
2. And looking for row 'SonarQube Server / {{ sonar_version }}' in {{ sonar_logs_dir }}/web.log

This slightly increase the time of role execution, but may provide additional info for troubleshooting.

Additional checks also help identify situations when sonar.service start but die in a minute or two. This time was enough to proceed with Molecule tests but the web UI wasn't started and service became broken. PR describe these findings:

1. Application stopped with next message in /opt/sonarqube/sonarqube-7.3/logs/sonar.log:

```
Launching a JVM...
Wrapper (Version 3.2.3) http://wrapper.tanukisoftware.org
  Copyright 1999-2006 Tanuki Software, Inc.  All Rights Reserved.

2021.01.10 12:24:25 INFO  app[][o.s.a.AppFileSystem] Cleaning or creating temp directory /opt/sonarqube/sonarqube-7.3/temp
2021.01.10 12:24:25 INFO  app[][o.s.a.es.EsSettings] Elasticsearch listening on /127.0.0.1:9001
2021.01.10 12:24:25 ERROR app[][o.s.a.p.SQProcess] Fail to launch process [es]
org.sonar.process.MessageException: a JVM option can't overwrite mandatory JVM options. The following JVM options defined by property 'sonar.search.javaOpts' are invalid: -Xss256k overwrite
s -Xss1m
2021.01.10 12:24:25 INFO  app[][o.s.a.SchedulerImpl] Process [es] is stopped
2021.01.10 12:24:25 INFO  app[][o.s.a.SchedulerImpl] SonarQube is stopped


WrapperSimpleApp: Encountered an error running main: org.sonar.process.MessageException: a JVM option can't overwrite mandatory JVM options. The following JVM options defined by property 's
onar.search.javaOpts' are invalid: -Xss256k overwrites -Xss1m
org.sonar.process.MessageException: a JVM option can't overwrite mandatory JVM options. The following JVM options defined by property 'sonar.search.javaOpts' are invalid: -Xss256k overwrite
s -Xss1m
<-- Wrapper Stopped
```
Unfortunately I haven't explanation why this problem wasn't reported by other users. In my setup the variable `sonar_search_java_opts` inherited these options from previous Sonar installation, I don't used the role defaults. 

https://github.com/lrk/ansible-role-sonarqube/commit/f0dbb74f5110ffc8542669d951b63a2e74302cd7 resolve it by setting `Xss` value to default recommended by https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html and [https://docs.oracle.com/en/java/javase/11/tools/java.htm](https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-3B1CE181-CD30-4178-9602-230B800D4FAE)

2. Second problem related to Debian 8. https://github.com/geerlingguy/ansible-role-java/blob/master/vars/Debian-8.yml installed the Java 7 doesn't compatible with Sonar per https://docs.sonarqube.org/7.3/Requirements.html. This caused application to stop with a message `Unsupported major.minor version 52.0`

Not sure how people prepared such configuration. Maybe openjdk-8-jdk was available in Debian repositories and they simply overrided the default `java_packages` (just assumption). Now it's could be a tricky because support for Debian Jessie seems to be ended on June 30, 2020 and addresses of it's repositories were changed.

For this PR I worked on stable test coverage, but also I wouldn't to change the role without strong need. To make test works I fixed an issue with Java 7 only in Molecule, without changing the role itself: https://github.com/lrk/ansible-role-sonarqube/commit/eeb1d841cb07179b6f09be3bfcfff8503a738584 with https://github.com/lrk/ansible-role-sonarqube/commit/71e56a60ffa75a187b78adc97b037e218a3b2ec8

If you plan further support Debian 8 - let to know and I'll rewrite my ugly workaround.

https://github.com/lrk/ansible-role-sonarqube/commit/8da3763f0496af546a7e38287c798998fce251fd instruct Ansible to run the `systemctl daemon-reload` on change to sonar.service file (caused by the upgrade or other changes)

I have to note that step `service_facts` take some time (maybe around 30 seconds). Maybe somebody will have better ideas for simple check if Sonar already installed.

Upgrade functionality was tested on real CentOS 7 system prepared by this role and containing the data.
Unfortunately I had no chance to verify how it works on non-systemd OSs.

Per the SonarQube documentation, upgrade require additional manual actions in browser - role documentation and handlers remind about this.

Best regards,
niluid