### PR TITLE
Convert generator to a list which can be accessed by index

### DIFF
--- a/tasks/setup_plugin_marketplace.yml
+++ b/tasks/setup_plugin_marketplace.yml
@@ -25,4 +25,4 @@
 
 - name: "set download url"
   set_fact:
-    cplugin_url: "{{ (plugin_info['versions']|selectattr('version','equalto',sonar_cplugin.version))[0]['downloadURL'] }}"
+    cplugin_url: "{{ ((plugin_info['versions']|selectattr('version','equalto',sonar_cplugin.version))|list)[0]['downloadURL'] }}"


### PR DESCRIPTION
Hi, I noticed, that with Ansible 2.9 the role threw errors while installing plugins from the marketspace. Can you confirm this issue and if yes, please integrate this fix into the role?